### PR TITLE
Remove incorrect `*.import` from `.gitignore` as it breaks plugin & add missing `*.import` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .import/
-*.import
 android/*
 !android/godot-camera-plugin.funabab/
 !android/.gdignore

--- a/addons/godot-camera-plugin.funabab/icon_camera.png.import
+++ b/addons/godot-camera-plugin.funabab/icon_camera.png.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/icon_camera.png-b2668087f7e7255e71cd8888d15ae040.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://addons/godot-camera-plugin.funabab/icon_camera.png"
+dest_files=[ "res://.import/icon_camera.png-b2668087f7e7255e71cd8888d15ae040.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/addons/godot-camera-plugin.funabab/icon_node.png.import
+++ b/addons/godot-camera-plugin.funabab/icon_node.png.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/icon_node.png-30f8f9efd25c6739f8122fe2bfd0aae8.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://addons/godot-camera-plugin.funabab/icon_node.png"
+dest_files=[ "res://.import/icon_node.png-30f8f9efd25c6739f8122fe2bfd0aae8.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0


### PR DESCRIPTION
This PR contains a two step fix--first we fix the `.gitignore` file & then we add the missing `*.png.import` files.

If the plugin does not contain the image-related `*.import` files
then the plugin fails to load the first time project is opened.

See here for "official" Godot `.gitignore` file: <https://github.com/github/gitignore/blob/master/Godot.gitignore>

The error on opening is (in a dialog box):

    Unable to load addon script from path: 'res://addons/godot-camera-plugin.funabab/plugin.gd' There seems to be an error in the code, please check the syntax.

But the underlying error (in the Output console) is:

    No loader found for resource: res://addons/godot-camera-plugin.funabab/icon_camera.png.
    res://addons/godot-camera-plugin.funabab/camera_view.gd:6 - Parse Error: Can't preload resource at path: res://addons/godot-camera-plugin.funabab/icon_camera.png

For additional context, see: <https://old.reddit.com/r/godot/comments/f4uhpk/i_get_stuck_with_android_plugin/>